### PR TITLE
scaler fitted to the training set only, then applied to test set

### DIFF
--- a/examples/boston.py
+++ b/examples/boston.py
@@ -25,19 +25,22 @@ random.seed(42)
 boston = datasets.load_boston()
 X, y = boston.data, boston.target
 
-# Scale data to 0 mean and unit std dev.
-scaler = preprocessing.StandardScaler()
-X = scaler.fit_transform(X)
-
 # Split dataset into train / test
 X_train, X_test, y_train, y_test = cross_validation.train_test_split(X, y,
     test_size=0.2, random_state=42)
+
+# scale data (training set) to 0 mean and unit Std. dev
+scaler = preprocessing.StandardScaler()
+X_train = scaler.fit_transform(X_train)
 
 # Build 2 layer fully connected DNN with 10, 10 units respecitvely.
 regressor = skflow.TensorFlowDNNRegressor(hidden_units=[10, 10],
     steps=5000, learning_rate=0.1, batch_size=1)
 
-# Fit and predict.
+# Fit
 regressor.fit(X_train, y_train)
-score = metrics.mean_squared_error(regressor.predict(X_test), y_test)
+
+# Predict and score
+score = metrics.mean_squared_error(regressor.predict(scaler.fit_transform(X_test)), y_test)
+
 print('MSE: {0:f}'.format(score))


### PR DESCRIPTION
Modified the boston.py example so that the standard scaler is fitted over the training set, not the whole dataset, and then applied to the test set. The MSE is improved to ~ 18.