### PR TITLE
Consistent usage of metrics.accuracy_score with the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ from sklearn import datasets, metrics
 iris = datasets.load_iris()
 classifier = skflow.TensorFlowLinearClassifier(n_classes=3)
 classifier.fit(iris.data, iris.target)
-score = metrics.accuracy_score(classifier.predict(iris.data), iris.target)
+score = metrics.accuracy_score(iris.target, classifier.predict(iris.data))
 print("Accuracy: %f" % score)
 ```
 
@@ -89,7 +89,7 @@ from sklearn import datasets, metrics
 iris = datasets.load_iris()
 classifier = skflow.TensorFlowDNNClassifier(hidden_units=[10, 20, 10], n_classes=3)
 classifier.fit(iris.data, iris.target)
-score = metrics.accuracy_score(classifier.predict(iris.data), iris.target)
+score = metrics.accuracy_score(iris.target, classifier.predict(iris.data))
 print("Accuracy: %f" % score)
 ```
 
@@ -110,7 +110,7 @@ def my_model(X, y):
 
 classifier = skflow.TensorFlowEstimator(model_fn=my_model, n_classes=3)
 classifier.fit(iris.data, iris.target)
-score = metrics.accuracy_score(classifier.predict(iris.data), iris.target)
+score = metrics.accuracy_score(iris.target, classifier.predict(iris.data))
 print("Accuracy: %f" % score)
 ```
 

--- a/examples/digits.py
+++ b/examples/digits.py
@@ -42,5 +42,5 @@ classifier = skflow.TensorFlowEstimator(model_fn=conv_model, n_classes=10,
                                         steps=500, learning_rate=0.05,
                                         batch_size=128)
 classifier.fit(X_train, y_train)
-score = metrics.accuracy_score(classifier.predict(X_test), y_test)
+score = metrics.accuracy_score(y_test, classifier.predict(X_test))
 print('Accuracy: {0:f}'.format(score))

--- a/examples/iris.py
+++ b/examples/iris.py
@@ -31,6 +31,6 @@ classifier = skflow.TensorFlowDNNClassifier(hidden_units=[10, 20, 10],
 
 # Fit and predict.
 classifier.fit(X_train, y_train)
-score = metrics.accuracy_score(classifier.predict(X_test), y_test)
+score = metrics.accuracy_score(y_test, classifier.predict(X_test))
 print('Accuracy: {0:f}'.format(score))
 

--- a/examples/iris_custom_decay_dnn.py
+++ b/examples/iris_custom_decay_dnn.py
@@ -39,4 +39,4 @@ classifier = skflow.TensorFlowDNNClassifier(hidden_units=[10, 20, 10],
                                             n_classes=3, steps=800,
                                             learning_rate=exp_decay)
 classifier.fit(X_train, y_train)
-score = metrics.accuracy_score(classifier.predict(X_test), y_test)
+score = metrics.accuracy_score(y_test, classifier.predict(X_test))

--- a/examples/iris_custom_model.py
+++ b/examples/iris_custom_model.py
@@ -31,6 +31,6 @@ def my_model(X, y):
 classifier = skflow.TensorFlowEstimator(model_fn=my_model, n_classes=3,
     steps=1000)
 classifier.fit(X_train, y_train)
-score = metrics.accuracy_score(classifier.predict(X_test), y_test)
+score = metrics.accuracy_score(y_test, classifier.predict(X_test))
 print('Accuracy: {0:f}'.format(score))
 

--- a/examples/iris_early_stopping.py
+++ b/examples/iris_early_stopping.py
@@ -35,15 +35,14 @@ X_train, X_test, y_train, y_test = train_test_split(iris.data,
 classifier1 = skflow.TensorFlowDNNClassifier(hidden_units=[10, 20, 10],
                                             n_classes=3, steps=800)
 classifier1.fit(X_train, y_train)
-score1 = metrics.accuracy_score(classifier1.predict(X_test), y_test)
+score1 = metrics.accuracy_score(y_test, classifier1.predict(X_test))
 
 # classifier with early stopping - improved accuracy on testing set
 classifier2 = skflow.TensorFlowDNNClassifier(hidden_units=[10, 20, 10],
                                             n_classes=3, steps=1000,
                                             early_stopping_rounds=200)
 classifier2.fit(X_train, y_train)
-score2 = metrics.accuracy_score(classifier2.predict(X_test), y_test)
+score2 = metrics.accuracy_score(y_test, classifier2.predict(X_test))
 
 # you can expect the score is improved by using early stopping
 print(score2 > score1)
-

--- a/examples/iris_save_restore.py
+++ b/examples/iris_save_restore.py
@@ -26,7 +26,7 @@ random.seed(42)
 
 classifier = skflow.TensorFlowLinearClassifier(n_classes=3)
 classifier.fit(X_train, y_train)
-score = metrics.accuracy_score(classifier.predict(X_test), y_test)
+score = metrics.accuracy_score(y_test, classifier.predict(X_test))
 print('Accuracy: {0:f}'.format(score))
 
 # Clean checkpoint folder if exists
@@ -41,6 +41,5 @@ classifier = None
 
 ## Restore everything
 new_classifier = skflow.TensorFlowEstimator.restore('/tmp/skflow_examples/iris_custom_model')
-score = metrics.accuracy_score(new_classifier.predict(X_test), y_test)
+score = metrics.accuracy_score(y_test, new_classifier.predict(X_test))
 print('Accuracy: {0:f}'.format(score))
-

--- a/examples/iris_with_pipeline.py
+++ b/examples/iris_with_pipeline.py
@@ -33,6 +33,6 @@ pipeline = Pipeline([('scaler', StandardScaler()), ('DNNclassifier', DNNclassifi
 
 pipeline.fit(X_train, y_train)
 
-score = accuracy_score(pipeline.predict(X_test), y_test)
+score = accuracy_score(y_test, pipeline.predict(X_test))
 
 print('Accuracy: {0:f}'.format(score))

--- a/examples/mnist.py
+++ b/examples/mnist.py
@@ -35,7 +35,7 @@ mnist = input_data.read_data_sets('MNIST_data')
 classifier = skflow.TensorFlowLinearClassifier(
     n_classes=10, batch_size=100, steps=1000, learning_rate=0.01)
 classifier.fit(mnist.train.images, mnist.train.labels)
-score = metrics.accuracy_score(classifier.predict(mnist.test.images), mnist.test.labels)
+score = metrics.accuracy_score(mnist.test.labels, classifier.predict(mnist.test.images))
 print('Accuracy: {0:f}'.format(score))
 
 ### Convolutional network
@@ -62,6 +62,5 @@ classifier = skflow.TensorFlowEstimator(
     model_fn=conv_model, n_classes=10, batch_size=100, steps=20000,
     learning_rate=0.001)
 classifier.fit(mnist.train.images, mnist.train.labels)
-score = metrics.accuracy_score(classifier.predict(mnist.test.images), mnist.test.labels)
+score = metrics.accuracy_score(mnist.test.labels, classifier.predict(mnist.test.images))
 print('Accuracy: {0:f}'.format(score))
-

--- a/examples/multiple_gpu.py
+++ b/examples/multiple_gpu.py
@@ -38,5 +38,5 @@ def my_model(X, y):
 
 classifier = skflow.TensorFlowEstimator(model_fn=my_model, n_classes=3)
 classifier.fit(X_train, y_train)
-score = metrics.accuracy_score(classifier.predict(X_test), y_test)
+score = metrics.accuracy_score(y_test, classifier.predict(X_test))
 print('Accuracy: {0:f}'.format(score))

--- a/examples/out_of_core_data_classification.py
+++ b/examples/out_of_core_data_classification.py
@@ -47,4 +47,4 @@ classifier.fit(X_train, y_train)
 # Make predictions on each partitions of testing data
 predictions = X_test.map_partitions(classifier.predict).compute()
 # Calculate accuracy
-score = metrics.accuracy_score(predictions, y_test.compute())
+score = metrics.accuracy_score(y_test.compute(), predictions)

--- a/examples/text_classification.py
+++ b/examples/text_classification.py
@@ -80,6 +80,6 @@ classifier = skflow.TensorFlowEstimator(model_fn=rnn_model, n_classes=15,
 # Continuesly train for 1000 steps & predict on test set.
 while True:
     classifier.fit(X_train, y_train, logdir='/tmp/tf_examples/word_rnn')
-    score = metrics.accuracy_score(classifier.predict(X_test), y_test)
+    score = metrics.accuracy_score(y_test, classifier.predict(X_test))
     print('Accuracy: {0:f}'.format(score))
 

--- a/examples/text_classification_character_cnn.py
+++ b/examples/text_classification_character_cnn.py
@@ -87,6 +87,6 @@ classifier = skflow.TensorFlowEstimator(model_fn=char_cnn_model, n_classes=15,
 # Continuesly train for 1000 steps & predict on test set.
 while True:
     classifier.fit(X_train, y_train)
-    score = metrics.accuracy_score(classifier.predict(X_test), y_test)
+    score = metrics.accuracy_score(y_test, classifier.predict(X_test))
     print("Accuracy: %f" % score)
 

--- a/examples/text_classification_character_rnn.py
+++ b/examples/text_classification_character_rnn.py
@@ -68,6 +68,6 @@ classifier = skflow.TensorFlowEstimator(model_fn=char_rnn_model, n_classes=15,
 # Continuesly train for 1000 steps & predict on test set.
 while True:
     classifier.fit(X_train, y_train)
-    score = metrics.accuracy_score(classifier.predict(X_test), y_test)
+    score = metrics.accuracy_score(y_test, classifier.predict(X_test))
     print("Accuracy: %f" % score)
 

--- a/examples/text_classification_cnn.py
+++ b/examples/text_classification_cnn.py
@@ -87,6 +87,6 @@ classifier = skflow.TensorFlowEstimator(model_fn=cnn_model, n_classes=15,
 # Continuesly train for 1000 steps & predict on test set.
 while True:
     classifier.fit(X_train, y_train, logdir='/tmp/tf_examples/word_cnn')
-    score = metrics.accuracy_score(classifier.predict(X_test), y_test)
+    score = metrics.accuracy_score(y_test, classifier.predict(X_test))
     print('Accuracy: {0:f}'.format(score))
 

--- a/examples/text_classification_save_restore.py
+++ b/examples/text_classification_save_restore.py
@@ -90,5 +90,5 @@ else:
             classifier.save(model_path)
             break
 # Predict on test set
-score = metrics.accuracy_score(classifier.predict(X_test), y_test)
+score = metrics.accuracy_score(y_test, classifier.predict(X_test))
 print('Accuracy: {0:f}'.format(score))

--- a/skflow/tests/test_base.py
+++ b/skflow/tests/test_base.py
@@ -41,7 +41,7 @@ class BaseTest(googletest.TestCase):
         iris = datasets.load_iris()
         classifier = skflow.TensorFlowLinearClassifier(n_classes=3)
         classifier.fit(iris.data, iris.target)
-        score = accuracy_score(classifier.predict(iris.data), iris.target)
+        score = accuracy_score(iris.target, classifier.predict(iris.data))
         self.assertGreater(score, 0.5, "Failed with score = {0}".format(score))
 
     def testIrisSummaries(self):
@@ -49,7 +49,7 @@ class BaseTest(googletest.TestCase):
         iris = datasets.load_iris()
         classifier = skflow.TensorFlowLinearClassifier(n_classes=3)
         classifier.fit(iris.data, iris.target, logdir='/tmp/skflow_tests/')
-        score = accuracy_score(classifier.predict(iris.data), iris.target)
+        score = accuracy_score(iris.target, classifier.predict(iris.data))
         self.assertGreater(score, 0.5, "Failed with score = {0}".format(score))
 
 
@@ -59,9 +59,9 @@ class BaseTest(googletest.TestCase):
         classifier = skflow.TensorFlowLinearClassifier(n_classes=3,
             learning_rate=0.05, continue_training=True)
         classifier.fit(iris.data, iris.target)
-        score1 = accuracy_score(classifier.predict(iris.data), iris.target)
+        score1 = accuracy_score(iris.target, classifier.predict(iris.data))
         classifier.fit(iris.data, iris.target)
-        score2 = accuracy_score(classifier.predict(iris.data), iris.target)
+        score2 = accuracy_score(iris.target, classifier.predict(iris.data))
         self.assertGreater(score2, score1,
                            "Failed with score = {0}".format(score2))
 
@@ -84,8 +84,8 @@ class BaseTest(googletest.TestCase):
 
         classifier = skflow.TensorFlowLinearClassifier(n_classes=3, steps=100)
         classifier.fit(iris_data(), iris_target())
-        score1 = accuracy_score(classifier.predict(iris.data), iris.target)
-        score2 = accuracy_score(classifier.predict(iris_predict_data()), iris.target)
+        score1 = accuracy_score(iris.target, classifier.predict(iris.data))
+        score2 = accuracy_score(iris.target, classifier.predict(iris_predict_data()))
         self.assertGreater(score1, 0.5, "Failed with score = {0}".format(score1))
         self.assertEqual(score2, score1, "Scores from {0} iterator doesn't "
                                          "match score {1} from full "

--- a/skflow/tests/test_custom_decay.py
+++ b/skflow/tests/test_custom_decay.py
@@ -41,7 +41,7 @@ class CustomDecayTest(googletest.TestCase):
                                                     n_classes=3, steps=800,
                                                     learning_rate=exp_decay)
         classifier.fit(X_train, y_train)
-        score = metrics.accuracy_score(classifier.predict(X_test), y_test)
+        score = metrics.accuracy_score(y_test, classifier.predict(X_test))
 
         self.assertGreater(score, 0.7, "Failed with score = {0}".format(score))
 

--- a/skflow/tests/test_early_stopping.py
+++ b/skflow/tests/test_early_stopping.py
@@ -37,14 +37,14 @@ class EarlyStoppingTest(googletest.TestCase):
         classifier1 = skflow.TensorFlowDNNClassifier(hidden_units=[10, 20, 10],
                                                     n_classes=3, steps=800)
         classifier1.fit(X_train, y_train)
-        score1 = metrics.accuracy_score(classifier1.predict(X_test), y_test)
+        score1 = metrics.accuracy_score(y_test, classifier1.predict(X_test))
 
         # classifier with early stopping - improved accuracy on testing set
         classifier2 = skflow.TensorFlowDNNClassifier(hidden_units=[10, 20, 10],
                                                     n_classes=3, steps=1000,
                                                     early_stopping_rounds=200)
         classifier2.fit(X_train, y_train)
-        score2 = metrics.accuracy_score(classifier2.predict(X_test), y_test)
+        score2 = metrics.accuracy_score(y_test, classifier2.predict(X_test))
 
         self.assertGreater(score2, score1, "No improvement using early stopping.")
 

--- a/skflow/tests/test_grid_search.py
+++ b/skflow/tests/test_grid_search.py
@@ -35,7 +35,7 @@ class GridSearchTest(googletest.TestCase):
             {'hidden_units': [[5, 5], [10, 10]],
              'learning_rate': [0.1, 0.01]})
         grid_search.fit(iris.data, iris.target)
-        score = accuracy_score(grid_search.predict(iris.data), iris.target)
+        score = accuracy_score(iris.target, grid_search.predict(iris.data))
         self.assertGreater(score, 0.5, "Failed with score = {0}".format(score))
 
 

--- a/skflow/tests/test_io.py
+++ b/skflow/tests/test_io.py
@@ -34,7 +34,7 @@ class IOTest(googletest.TestCase):
             labels = pd.DataFrame(iris.target)
             classifier = skflow.TensorFlowLinearClassifier(n_classes=3)
             classifier.fit(data, labels)
-            score = accuracy_score(classifier.predict(data), labels)
+            score = accuracy_score(labels, classifier.predict(data))
             self.assertGreater(score, 0.5, "Failed with score = {0}".format(score))
         else:
             print("No pandas installed. pandas-related tests are skipped.")
@@ -47,7 +47,7 @@ class IOTest(googletest.TestCase):
             labels = pd.Series(iris.target)
             classifier = skflow.TensorFlowLinearClassifier(n_classes=3)
             classifier.fit(data, labels)
-            score = accuracy_score(classifier.predict(data), labels)
+            score = accuracy_score(labels, classifier.predict(data))
             self.assertGreater(score, 0.5, "Failed with score = {0}".format(score))
 
     def test_string_data_formats(self):
@@ -89,7 +89,7 @@ class IOTest(googletest.TestCase):
             classifier = skflow.TensorFlowLinearClassifier(n_classes=3)
             classifier.fit(data, labels)
             predictions = data.map_partitions(classifier.predict).compute()
-            score = accuracy_score(predictions, labels.compute())
+            score = accuracy_score(labels.compute(), predictions)
             self.assertGreater(score, 0.5, "Failed with score = {0}".format(score))
 
 if __name__ == '__main__':

--- a/skflow/tests/test_multioutput.py
+++ b/skflow/tests/test_multioutput.py
@@ -46,7 +46,7 @@ class MultiOutputTest(googletest.TestCase):
                                                        random_state=42)
         #classifier = skflow.TensorFlowLinearClassifier(n_classes=n_classes)
         #classifier.fit(X, y)
-        #score = accuracy_score(classifier.predict(X), y)
+        #score = accuracy_score(y, classifier.predict(X))
         #self.assertGreater(score, 0.5, "Failed with score = {0}".format(score))
 
 

--- a/skflow/tests/test_nonlinear.py
+++ b/skflow/tests/test_nonlinear.py
@@ -31,7 +31,7 @@ class NonLinearTest(googletest.TestCase):
         classifier = skflow.TensorFlowDNNClassifier(
             hidden_units=[10, 20, 10], n_classes=3)
         classifier.fit(iris.data, iris.target)
-        score = accuracy_score(classifier.predict(iris.data), iris.target)
+        score = accuracy_score(iris.target, classifier.predict(iris.data))
         self.assertGreater(score, 0.5, "Failed with score = {0}".format(score))
 
     def testBoston(self):

--- a/skflow/tests/test_saver.py
+++ b/skflow/tests/test_saver.py
@@ -35,7 +35,7 @@ class SaverTest(googletest.TestCase):
         classifier.save(path)
         new_classifier = skflow.TensorFlowEstimator.restore(path)
         self.assertEqual(type(new_classifier), type(classifier))
-        score = accuracy_score(new_classifier.predict(iris.data), iris.target)
+        score = accuracy_score(iris.target, new_classifier.predict(iris.data))
         self.assertGreater(score, 0.5, "Failed with score = {0}".format(score))
 
     def testCustomModel(self):
@@ -50,7 +50,7 @@ class SaverTest(googletest.TestCase):
         classifier.save(path)
         new_classifier = skflow.TensorFlowEstimator.restore(path)
         self.assertEqual(type(new_classifier), type(classifier))
-        score = accuracy_score(new_classifier.predict(iris.data), iris.target)
+        score = accuracy_score(iris.target, new_classifier.predict(iris.data))
         self.assertGreater(score, 0.5, "Failed with score = {0}".format(score))
     
     def testDNN(self):
@@ -62,7 +62,7 @@ class SaverTest(googletest.TestCase):
         classifier.save(path)
         new_classifier = skflow.TensorFlowEstimator.restore(path)
         self.assertEqual(type(new_classifier), type(classifier))
-        score = accuracy_score(new_classifier.predict(iris.data), iris.target)
+        score = accuracy_score(iris.target, new_classifier.predict(iris.data))
         self.assertGreater(score, 0.5, "Failed with score = {0}".format(score))
 
     def testNoFolder(self):


### PR DESCRIPTION
It seems to me that arguments passed to `metrics.accuracy_score` are inverted when looking at:
http://scikit-learn.org/stable/modules/generated/sklearn.metrics.accuracy_score.html#sklearn.metrics.accuracy_score

Although it does not affect the result of `accuracy_score`, it does affect other functions under the `metrics` module, and may thus be slightly misleading.