### PR TITLE
Fix dropout management in TensorFlowEstimator._predict

### DIFF
--- a/skflow/estimators/base.py
+++ b/skflow/estimators/base.py
@@ -243,8 +243,8 @@ class TensorFlowEstimator(BaseEstimator):
             raise NotFittedError()
         predict_data_feeder = setup_predict_data_feeder(X)
         preds = []
-        dropouts = tf.get_collection(DROPOUTS)
-        feed_dict = {prob: 0.0 for prob in dropouts}
+        dropouts = self._graph.get_collection(DROPOUTS)
+        feed_dict = {prob: 1.0 for prob in dropouts}
         for data in predict_data_feeder:
             feed_dict[self._inp] = data
             preds.append(self._session.run(


### PR DESCRIPTION
get correct list of dropout variables, pass keep_prob = 1.0 - see https://github.com/tensorflow/skflow/pull/81#discussion_r51421870