### PR TITLE
Add early stopping and reporting based on validation data

### DIFF
--- a/examples/digits.py
+++ b/examples/digits.py
@@ -27,12 +27,15 @@ y = digits.target
 # Split it into train / test subsets
 
 X_train, X_test, y_train, y_test = cross_validation.train_test_split(X, y,
-                                            test_size=0.2, random_state=42)
+                                                                     test_size=0.2,
+                                                                     random_state=42)
 
 # Split X_train again to create validation data
 
-X_train, X_val, y_train, y_val = cross_validation.train_test_split(X_train, y_train,
-                                            test_size=0.2, random_state=42)
+X_train, X_val, y_train, y_val = cross_validation.train_test_split(X_train,
+                                                                   y_train,
+                                                                   test_size=0.2,
+                                                                   random_state=42)
 
 # TensorFlow model using Scikit Flow ops
 
@@ -47,7 +50,7 @@ val_monitor = monitors.ValidationMonitor(X_val, y_val, n_classes=10)
 # Create a classifier, train and predict.
 classifier = skflow.TensorFlowEstimator(model_fn=conv_model, n_classes=10,
                                         steps=1000, learning_rate=0.05,
-                                        batch_size=128, monitor=val_monitor)
-classifier.fit(X_train, y_train)
+                                        batch_size=128)
+classifier.fit(X_train, y_train, val_monitor)
 score = metrics.accuracy_score(y_test, classifier.predict(X_test))
 print('Test Accuracy: {0:f}'.format(score))

--- a/examples/digits.py
+++ b/examples/digits.py
@@ -46,7 +46,7 @@ def conv_model(X, y):
     features = tf.reshape(features, [-1, 12])
     return skflow.models.logistic_regression(features, y)
 
-val_monitor = monitors.ValidationMonitor(X_val, y_val, n_classes=10)
+val_monitor = monitors.ValidationMonitor(X_val, y_val, n_classes=10, print_steps=50)
 # Create a classifier, train and predict.
 classifier = skflow.TensorFlowEstimator(model_fn=conv_model, n_classes=10,
                                         steps=1000, learning_rate=0.05,

--- a/examples/digits.py
+++ b/examples/digits.py
@@ -16,8 +16,9 @@ from sklearn import datasets, cross_validation, metrics
 import tensorflow as tf
 
 import skflow
+from skflow import monitors
 
-# Load dataset 
+# Load dataset
 
 digits = datasets.load_digits()
 X = digits.images
@@ -26,14 +27,15 @@ y = digits.target
 # Split it into train / test subsets
 
 X_train, X_test, y_train, y_test = cross_validation.train_test_split(X, y,
-    test_size=0.2, random_state=42)
+                                            test_size=0.2, random_state=42)
 
 # Split X_train again to create validation data
 
 X_train, X_val, y_train, y_val = cross_validation.train_test_split(X_train, y_train,
-    test_size=0.2, random_state=42)
+                                            test_size=0.2, random_state=42)
 
 # TensorFlow model using Scikit Flow ops
+
 
 def conv_model(X, y):
     X = tf.expand_dims(X, 3)
@@ -41,10 +43,11 @@ def conv_model(X, y):
     features = tf.reshape(features, [-1, 12])
     return skflow.models.logistic_regression(features, y)
 
+val_monitor = monitors.ValidationMonitor(X_val, y_val, n_classes=10)
 # Create a classifier, train and predict.
 classifier = skflow.TensorFlowEstimator(model_fn=conv_model, n_classes=10,
                                         steps=1000, learning_rate=0.05,
-                                        batch_size=128, early_stopping_rounds=200)
-classifier.fit(X_train, y_train, X_val, y_val)
+                                        batch_size=128, monitor=val_monitor)
+classifier.fit(X_train, y_train)
 score = metrics.accuracy_score(y_test, classifier.predict(X_test))
 print('Test Accuracy: {0:f}'.format(score))

--- a/examples/digits.py
+++ b/examples/digits.py
@@ -17,13 +17,20 @@ import tensorflow as tf
 
 import skflow
 
-# Load dataset and split it into train / test subsets.
+# Load dataset 
 
 digits = datasets.load_digits()
 X = digits.images
 y = digits.target
 
+# Split it into train / test subsets
+
 X_train, X_test, y_train, y_test = cross_validation.train_test_split(X, y,
+    test_size=0.2, random_state=42)
+
+# Split X_train again to create validation data
+
+X_train, X_val, y_train, y_val = cross_validation.train_test_split(X_train, y_train,
     test_size=0.2, random_state=42)
 
 # TensorFlow model using Scikit Flow ops
@@ -36,8 +43,8 @@ def conv_model(X, y):
 
 # Create a classifier, train and predict.
 classifier = skflow.TensorFlowEstimator(model_fn=conv_model, n_classes=10,
-                                        steps=500, learning_rate=0.05,
-                                        batch_size=128)
-classifier.fit(X_train, y_train)
+                                        steps=1000, learning_rate=0.05,
+                                        batch_size=128, early_stopping_rounds=200)
+classifier.fit(X_train, y_train, X_val, y_val)
 score = metrics.accuracy_score(y_test, classifier.predict(X_test))
-print('Accuracy: {0:f}'.format(score))
+print('Test Accuracy: {0:f}'.format(score))

--- a/examples/iris_val_based_early_stopping.py
+++ b/examples/iris_val_based_early_stopping.py
@@ -12,7 +12,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import tensorflow as tf
 from tensorflow.python.platform import googletest
 
 from sklearn import datasets, metrics
@@ -27,18 +26,23 @@ X_train, X_test, y_train, y_test = train_test_split(iris.data,
                                                     test_size=0.2,
                                                     random_state=42)
 
-# classifier without early stopping - overfitting
+X_train, X_val, y_train, y_val = train_test_split(X_train, y_train,
+                                                  test_size=0.2, random_state=42)
+val_monitor = skflow.monitors.ValidationMonitor(X_val, y_val,
+                                                early_stopping_rounds=200,
+                                                n_classes=3)
+
+# classifier with early stopping on training data
 classifier1 = skflow.TensorFlowDNNClassifier(hidden_units=[10, 20, 10],
-                                            n_classes=3, steps=800)
+                                             n_classes=3, steps=2000)
 classifier1.fit(X_train, y_train)
 score1 = metrics.accuracy_score(y_test, classifier1.predict(X_test))
 
-# classifier with early stopping - improved accuracy on testing set
+# classifier with early stopping on validation data
 classifier2 = skflow.TensorFlowDNNClassifier(hidden_units=[10, 20, 10],
-                                            n_classes=3, steps=1000,
-                                            early_stopping_rounds=200)
-classifier2.fit(X_train, y_train)
+                                             n_classes=3, steps=2000)
+classifier2.fit(X_train, y_train, val_monitor)
 score2 = metrics.accuracy_score(y_test, classifier2.predict(X_test))
 
-# you can expect the score is improved by using early stopping
+# in many applications, the score is improved by using early stopping on val data
 print(score2 > score1)

--- a/skflow/estimators/base.py
+++ b/skflow/estimators/base.py
@@ -200,7 +200,7 @@ class TensorFlowEstimator(BaseEstimator):
                                                     self.batch_size)
 
         if monitor is None:
-            self._monitor = monitors.BaseMonitor()
+            self._monitor = monitors.default_monitor()
         else:
             self._monitor = monitor
 

--- a/skflow/estimators/dnn.py
+++ b/skflow/estimators/dnn.py
@@ -49,23 +49,22 @@ class TensorFlowDNNClassifier(TensorFlowEstimator, ClassifierMixin):
             model will be continuely trained on every call of fit.
         config_addon: ConfigAddon object that controls the configurations of the session,
             e.g. num_cores, gpu_memory_fraction, etc.
-        early_stopping_rounds: Activates early stopping if this is not None.
-            Loss needs to decrease at least every every <early_stopping_rounds>
-            round(s) to continue training. (default: None)
         max_to_keep: The maximum number of recent checkpoint files to keep.
             As new files are created, older files are deleted.
             If None or 0, all checkpoint files are kept.
             Defaults to 5 (that is, the 5 most recent checkpoint files are kept.)
         keep_checkpoint_every_n_hours: Number of hours between each checkpoint
             to be saved. The default value of 10,000 hours effectively disables the feature.
+        monitor: Monitor object to track of training progress (and induce early stopping)
      """
 
     def __init__(self, hidden_units, n_classes, tf_master="", batch_size=32,
                  steps=200, optimizer="SGD", learning_rate=0.1,
                  class_weight=None,
                  tf_random_seed=42, continue_training=False, config_addon=None,
-                 verbose=1, early_stopping_rounds=None,
-                 max_to_keep=5, keep_checkpoint_every_n_hours=10000):
+                 verbose=1, max_to_keep=5, keep_checkpoint_every_n_hours=10000,
+                 monitor=None):
+
         self.hidden_units = hidden_units
         super(TensorFlowDNNClassifier, self).__init__(
             model_fn=self._model_fn,
@@ -75,9 +74,9 @@ class TensorFlowDNNClassifier(TensorFlowEstimator, ClassifierMixin):
             tf_random_seed=tf_random_seed,
             continue_training=continue_training,
             config_addon=config_addon, verbose=verbose,
-            early_stopping_rounds=early_stopping_rounds,
             max_to_keep=max_to_keep,
-            keep_checkpoint_every_n_hours=keep_checkpoint_every_n_hours)
+            keep_checkpoint_every_n_hours=keep_checkpoint_every_n_hours,
+            monitor=monitor)
 
     def _model_fn(self, X, y):
         return models.get_dnn_model(self.hidden_units,
@@ -126,29 +125,25 @@ class TensorFlowDNNRegressor(TensorFlowEstimator, RegressorMixin):
             model will be continuely trained on every call of fit.
         config_addon: ConfigAddon object that controls the configurations of the session,
             e.g. num_cores, gpu_memory_fraction, etc.
-        early_stopping_rounds: Activates early stopping if this is not None.
-            Loss needs to decrease at least every every <early_stopping_rounds>
-            round(s) to continue training. (default: None)
         verbose: Controls the verbosity, possible values:
                  0: the algorithm and debug information is muted.
                  1: trainer prints the progress.
                  2: log device placement is printed.
-        early_stopping_rounds: Activates early stopping if this is not None.
-            Loss needs to decrease at least every every <early_stopping_rounds>
-            round(s) to continue training. (default: None)
         max_to_keep: The maximum number of recent checkpoint files to keep.
             As new files are created, older files are deleted.
             If None or 0, all checkpoint files are kept.
             Defaults to 5 (that is, the 5 most recent checkpoint files are kept.)
         keep_checkpoint_every_n_hours: Number of hours between each checkpoint
             to be saved. The default value of 10,000 hours effectively disables the feature.
+        monitor: Monitor object to track of training progress (and induce early stopping)
    """
 
     def __init__(self, hidden_units, n_classes=0, tf_master="", batch_size=32,
                  steps=200, optimizer="SGD", learning_rate=0.1,
                  tf_random_seed=42, continue_training=False, config_addon=None,
-                 verbose=1, early_stopping_rounds=None,
-                 max_to_keep=5, keep_checkpoint_every_n_hours=10000):
+                 verbose=1, max_to_keep=5, keep_checkpoint_every_n_hours=10000,
+                 monitor=None):
+
         self.hidden_units = hidden_units
         super(TensorFlowDNNRegressor, self).__init__(
             model_fn=self._model_fn,
@@ -157,9 +152,9 @@ class TensorFlowDNNRegressor(TensorFlowEstimator, RegressorMixin):
             learning_rate=learning_rate, tf_random_seed=tf_random_seed,
             continue_training=continue_training,
             config_addon=config_addon, verbose=verbose,
-            early_stopping_rounds=early_stopping_rounds,
             max_to_keep=max_to_keep,
-            keep_checkpoint_every_n_hours=keep_checkpoint_every_n_hours)
+            keep_checkpoint_every_n_hours=keep_checkpoint_every_n_hours,
+            monitor=monitor)
 
     def _model_fn(self, X, y):
         return models.get_dnn_model(self.hidden_units,
@@ -182,4 +177,3 @@ class TensorFlowDNNRegressor(TensorFlowEstimator, RegressorMixin):
             biases.append(self.get_tensor_value('dnn/layer%d/Linear/Bias:0' % layer))
         biases.append(self.get_tensor_value('linear_regression/bias:0'))
         return biases
-

--- a/skflow/estimators/dnn.py
+++ b/skflow/estimators/dnn.py
@@ -55,15 +55,13 @@ class TensorFlowDNNClassifier(TensorFlowEstimator, ClassifierMixin):
             Defaults to 5 (that is, the 5 most recent checkpoint files are kept.)
         keep_checkpoint_every_n_hours: Number of hours between each checkpoint
             to be saved. The default value of 10,000 hours effectively disables the feature.
-        monitor: Monitor object to track of training progress (and induce early stopping)
      """
 
     def __init__(self, hidden_units, n_classes, tf_master="", batch_size=32,
                  steps=200, optimizer="SGD", learning_rate=0.1,
                  class_weight=None,
                  tf_random_seed=42, continue_training=False, config_addon=None,
-                 verbose=1, max_to_keep=5, keep_checkpoint_every_n_hours=10000,
-                 monitor=None):
+                 verbose=1, max_to_keep=5, keep_checkpoint_every_n_hours=10000):
 
         self.hidden_units = hidden_units
         super(TensorFlowDNNClassifier, self).__init__(
@@ -75,8 +73,7 @@ class TensorFlowDNNClassifier(TensorFlowEstimator, ClassifierMixin):
             continue_training=continue_training,
             config_addon=config_addon, verbose=verbose,
             max_to_keep=max_to_keep,
-            keep_checkpoint_every_n_hours=keep_checkpoint_every_n_hours,
-            monitor=monitor)
+            keep_checkpoint_every_n_hours=keep_checkpoint_every_n_hours)
 
     def _model_fn(self, X, y):
         return models.get_dnn_model(self.hidden_units,
@@ -135,14 +132,12 @@ class TensorFlowDNNRegressor(TensorFlowEstimator, RegressorMixin):
             Defaults to 5 (that is, the 5 most recent checkpoint files are kept.)
         keep_checkpoint_every_n_hours: Number of hours between each checkpoint
             to be saved. The default value of 10,000 hours effectively disables the feature.
-        monitor: Monitor object to track of training progress (and induce early stopping)
    """
 
     def __init__(self, hidden_units, n_classes=0, tf_master="", batch_size=32,
                  steps=200, optimizer="SGD", learning_rate=0.1,
                  tf_random_seed=42, continue_training=False, config_addon=None,
-                 verbose=1, max_to_keep=5, keep_checkpoint_every_n_hours=10000,
-                 monitor=None):
+                 verbose=1, max_to_keep=5, keep_checkpoint_every_n_hours=10000):
 
         self.hidden_units = hidden_units
         super(TensorFlowDNNRegressor, self).__init__(
@@ -153,8 +148,7 @@ class TensorFlowDNNRegressor(TensorFlowEstimator, RegressorMixin):
             continue_training=continue_training,
             config_addon=config_addon, verbose=verbose,
             max_to_keep=max_to_keep,
-            keep_checkpoint_every_n_hours=keep_checkpoint_every_n_hours,
-            monitor=monitor)
+            keep_checkpoint_every_n_hours=keep_checkpoint_every_n_hours)
 
     def _model_fn(self, X, y):
         return models.get_dnn_model(self.hidden_units,

--- a/skflow/estimators/linear.py
+++ b/skflow/estimators/linear.py
@@ -27,8 +27,7 @@ class TensorFlowLinearRegressor(TensorFlowEstimator, RegressorMixin):
     def __init__(self, n_classes=0, tf_master="", batch_size=32, steps=200, optimizer="SGD",
                  learning_rate=0.1, tf_random_seed=42, continue_training=False,
                  config_addon=None, verbose=1,
-                 max_to_keep=5, keep_checkpoint_every_n_hours=10000,
-                 monitor=None):
+                 max_to_keep=5, keep_checkpoint_every_n_hours=10000):
 
         super(TensorFlowLinearRegressor, self).__init__(
             model_fn=models.linear_regression, n_classes=n_classes,
@@ -37,8 +36,7 @@ class TensorFlowLinearRegressor(TensorFlowEstimator, RegressorMixin):
             learning_rate=learning_rate, tf_random_seed=tf_random_seed,
             continue_training=continue_training, config_addon=config_addon,
             verbose=verbose, max_to_keep=max_to_keep,
-            keep_checkpoint_every_n_hours=keep_checkpoint_every_n_hours,
-            monitor=monitor)
+            keep_checkpoint_every_n_hours=keep_checkpoint_every_n_hours)
 
     @property
     def weights_(self):
@@ -57,8 +55,7 @@ class TensorFlowLinearClassifier(TensorFlowEstimator, ClassifierMixin):
     def __init__(self, n_classes, tf_master="", batch_size=32, steps=200, optimizer="SGD",
                  learning_rate=0.1, class_weight=None,
                  tf_random_seed=42, continue_training=False, config_addon=None,
-                 verbose=1, max_to_keep=5, keep_checkpoint_every_n_hours=10000,
-                 monitor=None):
+                 verbose=1, max_to_keep=5, keep_checkpoint_every_n_hours=10000):
 
         super(TensorFlowLinearClassifier, self).__init__(
             model_fn=models.logistic_regression, n_classes=n_classes,
@@ -68,8 +65,7 @@ class TensorFlowLinearClassifier(TensorFlowEstimator, ClassifierMixin):
             tf_random_seed=tf_random_seed,
             continue_training=continue_training, config_addon=config_addon,
             verbose=verbose, max_to_keep=max_to_keep,
-            keep_checkpoint_every_n_hours=keep_checkpoint_every_n_hours,
-            monitor=monitor)
+            keep_checkpoint_every_n_hours=keep_checkpoint_every_n_hours)
 
     @property
     def weights_(self):

--- a/skflow/estimators/linear.py
+++ b/skflow/estimators/linear.py
@@ -26,17 +26,19 @@ class TensorFlowLinearRegressor(TensorFlowEstimator, RegressorMixin):
 
     def __init__(self, n_classes=0, tf_master="", batch_size=32, steps=200, optimizer="SGD",
                  learning_rate=0.1, tf_random_seed=42, continue_training=False,
-                 config_addon=None, verbose=1, early_stopping_rounds=None,
-                 max_to_keep=5, keep_checkpoint_every_n_hours=10000):
+                 config_addon=None, verbose=1,
+                 max_to_keep=5, keep_checkpoint_every_n_hours=10000,
+                 monitor=None):
+
         super(TensorFlowLinearRegressor, self).__init__(
             model_fn=models.linear_regression, n_classes=n_classes,
             tf_master=tf_master,
             batch_size=batch_size, steps=steps, optimizer=optimizer,
             learning_rate=learning_rate, tf_random_seed=tf_random_seed,
             continue_training=continue_training, config_addon=config_addon,
-            verbose=verbose, early_stopping_rounds=early_stopping_rounds,
-            max_to_keep=max_to_keep,
-            keep_checkpoint_every_n_hours=keep_checkpoint_every_n_hours)
+            verbose=verbose, max_to_keep=max_to_keep,
+            keep_checkpoint_every_n_hours=keep_checkpoint_every_n_hours,
+            monitor=monitor)
 
     @property
     def weights_(self):
@@ -55,8 +57,9 @@ class TensorFlowLinearClassifier(TensorFlowEstimator, ClassifierMixin):
     def __init__(self, n_classes, tf_master="", batch_size=32, steps=200, optimizer="SGD",
                  learning_rate=0.1, class_weight=None,
                  tf_random_seed=42, continue_training=False, config_addon=None,
-                 verbose=1, early_stopping_rounds=None,
-                 max_to_keep=5, keep_checkpoint_every_n_hours=10000):
+                 verbose=1, max_to_keep=5, keep_checkpoint_every_n_hours=10000,
+                 monitor=None):
+
         super(TensorFlowLinearClassifier, self).__init__(
             model_fn=models.logistic_regression, n_classes=n_classes,
             tf_master=tf_master,
@@ -64,9 +67,9 @@ class TensorFlowLinearClassifier(TensorFlowEstimator, ClassifierMixin):
             learning_rate=learning_rate, class_weight=class_weight,
             tf_random_seed=tf_random_seed,
             continue_training=continue_training, config_addon=config_addon,
-            verbose=verbose, early_stopping_rounds=early_stopping_rounds,
-            max_to_keep=max_to_keep,
-            keep_checkpoint_every_n_hours=keep_checkpoint_every_n_hours)
+            verbose=verbose, max_to_keep=max_to_keep,
+            keep_checkpoint_every_n_hours=keep_checkpoint_every_n_hours,
+            monitor=monitor)
 
     @property
     def weights_(self):

--- a/skflow/estimators/rnn.py
+++ b/skflow/estimators/rnn.py
@@ -69,7 +69,6 @@ class TensorFlowRNNClassifier(TensorFlowEstimator, ClassifierMixin):
             Defaults to 5 (that is, the 5 most recent checkpoint files are kept.)
         keep_checkpoint_every_n_hours: Number of hours between each checkpoint
             to be saved. The default value of 10,000 hours effectively disables the feature.
-        monitor: Monitor object to track of training progress (and induce early stopping)
      """
 
     def __init__(self, rnn_size, n_classes, cell_type='gru', num_layers=1,
@@ -80,8 +79,7 @@ class TensorFlowRNNClassifier(TensorFlowEstimator, ClassifierMixin):
                  class_weight=None,
                  tf_random_seed=42, continue_training=False,
                  config_addon=None, verbose=1,
-                 max_to_keep=5, keep_checkpoint_every_n_hours=10000,
-                 monitor=None):
+                 max_to_keep=5, keep_checkpoint_every_n_hours=10000):
 
         self.rnn_size = rnn_size
         self.cell_type = cell_type
@@ -99,8 +97,7 @@ class TensorFlowRNNClassifier(TensorFlowEstimator, ClassifierMixin):
             continue_training=continue_training, config_addon=config_addon,
             verbose=verbose,
             max_to_keep=max_to_keep,
-            keep_checkpoint_every_n_hours=keep_checkpoint_every_n_hours,
-            monitor=monitor)
+            keep_checkpoint_every_n_hours=keep_checkpoint_every_n_hours)
 
     def _model_fn(self, X, y):
         return models.get_rnn_model(self.rnn_size, self.cell_type,
@@ -164,7 +161,6 @@ class TensorFlowRNNRegressor(TensorFlowEstimator, RegressorMixin):
             Defaults to 5 (that is, the 5 most recent checkpoint files are kept.)
         keep_checkpoint_every_n_hours: Number of hours between each checkpoint
             to be saved. The default value of 10,000 hours effectively disables the feature.
-        monitor: Monitor object to track of training progress (and induce early stopping)
    """
 
     def __init__(self, rnn_size, cell_type='gru', num_layers=1,
@@ -174,8 +170,7 @@ class TensorFlowRNNRegressor(TensorFlowEstimator, RegressorMixin):
                  steps=50, optimizer="SGD", learning_rate=0.1,
                  tf_random_seed=42, continue_training=False,
                  config_addon=None, verbose=1,
-                 max_to_keep=5, keep_checkpoint_every_n_hours=10000,
-                 monitor=None):
+                 max_to_keep=5, keep_checkpoint_every_n_hours=10000):
 
         self.rnn_size = rnn_size
         self.cell_type = cell_type
@@ -191,8 +186,7 @@ class TensorFlowRNNRegressor(TensorFlowEstimator, RegressorMixin):
             learning_rate=learning_rate, tf_random_seed=tf_random_seed,
             continue_training=continue_training, config_addon=config_addon,
             verbose=verbose, max_to_keep=max_to_keep,
-            keep_checkpoint_every_n_hours=keep_checkpoint_every_n_hours,
-            monitor=monitor)
+            keep_checkpoint_every_n_hours=keep_checkpoint_every_n_hours)
 
     def _model_fn(self, X, y):
         return models.get_rnn_model(self.rnn_size, self.cell_type,

--- a/skflow/estimators/rnn.py
+++ b/skflow/estimators/rnn.py
@@ -25,6 +25,7 @@ def null_input_op_fn(X):
     """This function does no transformation on the inputs, used as default"""
     return X
 
+
 class TensorFlowRNNClassifier(TensorFlowEstimator, ClassifierMixin):
     """TensorFlow RNN Classifier model.
 
@@ -62,15 +63,13 @@ class TensorFlowRNNClassifier(TensorFlowEstimator, ClassifierMixin):
         continue_training: when continue_training is True, once initialized
             model will be continuely trained on every call of fit.
         num_cores: Number of cores to be used. (default: 4)
-        early_stopping_rounds: Activates early stopping if this is not None.
-            Loss needs to decrease at least every every <early_stopping_rounds>
-            round(s) to continue training. (default: None)
         max_to_keep: The maximum number of recent checkpoint files to keep.
             As new files are created, older files are deleted.
             If None or 0, all checkpoint files are kept.
             Defaults to 5 (that is, the 5 most recent checkpoint files are kept.)
         keep_checkpoint_every_n_hours: Number of hours between each checkpoint
             to be saved. The default value of 10,000 hours effectively disables the feature.
+        monitor: Monitor object to track of training progress (and induce early stopping)
      """
 
     def __init__(self, rnn_size, n_classes, cell_type='gru', num_layers=1,
@@ -80,8 +79,10 @@ class TensorFlowRNNClassifier(TensorFlowEstimator, ClassifierMixin):
                  steps=50, optimizer="SGD", learning_rate=0.1,
                  class_weight=None,
                  tf_random_seed=42, continue_training=False,
-                 config_addon=None, verbose=1, early_stopping_rounds=None,
-                 max_to_keep=5, keep_checkpoint_every_n_hours=10000):
+                 config_addon=None, verbose=1,
+                 max_to_keep=5, keep_checkpoint_every_n_hours=10000,
+                 monitor=None):
+
         self.rnn_size = rnn_size
         self.cell_type = cell_type
         self.input_op_fn = input_op_fn
@@ -97,9 +98,9 @@ class TensorFlowRNNClassifier(TensorFlowEstimator, ClassifierMixin):
             tf_random_seed=tf_random_seed,
             continue_training=continue_training, config_addon=config_addon,
             verbose=verbose,
-            early_stopping_rounds=early_stopping_rounds,
             max_to_keep=max_to_keep,
-            keep_checkpoint_every_n_hours=keep_checkpoint_every_n_hours)
+            keep_checkpoint_every_n_hours=keep_checkpoint_every_n_hours,
+            monitor=monitor)
 
     def _model_fn(self, X, y):
         return models.get_rnn_model(self.rnn_size, self.cell_type,
@@ -153,22 +154,17 @@ class TensorFlowRNNRegressor(TensorFlowEstimator, RegressorMixin):
         continue_training: when continue_training is True, once initialized
             model will be continuely trained on every call of fit.
         num_cores: Number of cores to be used. (default: 4)
-        early_stopping_rounds: Activates early stopping if this is not None.
-            Loss needs to decrease at least every every <early_stopping_rounds>
-            round(s) to continue training. (default: None)
         verbose: Controls the verbosity, possible values:
                  0: the algorithm and debug information is muted.
                  1: trainer prints the progress.
                  2: log device placement is printed.
-        early_stopping_rounds: Activates early stopping if this is not None.
-            Loss needs to decrease at least every every <early_stopping_rounds>
-            round(s) to continue training. (default: None)
         max_to_keep: The maximum number of recent checkpoint files to keep.
             As new files are created, older files are deleted.
             If None or 0, all checkpoint files are kept.
             Defaults to 5 (that is, the 5 most recent checkpoint files are kept.)
         keep_checkpoint_every_n_hours: Number of hours between each checkpoint
             to be saved. The default value of 10,000 hours effectively disables the feature.
+        monitor: Monitor object to track of training progress (and induce early stopping)
    """
 
     def __init__(self, rnn_size, cell_type='gru', num_layers=1,
@@ -177,8 +173,10 @@ class TensorFlowRNNRegressor(TensorFlowEstimator, RegressorMixin):
                  n_classes=0, tf_master="", batch_size=32,
                  steps=50, optimizer="SGD", learning_rate=0.1,
                  tf_random_seed=42, continue_training=False,
-                 config_addon=None, verbose=1, early_stopping_rounds=None,
-                 max_to_keep=5, keep_checkpoint_every_n_hours=10000):
+                 config_addon=None, verbose=1,
+                 max_to_keep=5, keep_checkpoint_every_n_hours=10000,
+                 monitor=None):
+
         self.rnn_size = rnn_size
         self.cell_type = cell_type
         self.input_op_fn = input_op_fn
@@ -192,10 +190,9 @@ class TensorFlowRNNRegressor(TensorFlowEstimator, RegressorMixin):
             batch_size=batch_size, steps=steps, optimizer=optimizer,
             learning_rate=learning_rate, tf_random_seed=tf_random_seed,
             continue_training=continue_training, config_addon=config_addon,
-            verbose=verbose,
-            early_stopping_rounds=early_stopping_rounds,
-            max_to_keep=max_to_keep,
-            keep_checkpoint_every_n_hours=keep_checkpoint_every_n_hours)
+            verbose=verbose, max_to_keep=max_to_keep,
+            keep_checkpoint_every_n_hours=keep_checkpoint_every_n_hours,
+            monitor=monitor)
 
     def _model_fn(self, X, y):
         return models.get_rnn_model(self.rnn_size, self.cell_type,

--- a/skflow/monitors.py
+++ b/skflow/monitors.py
@@ -26,16 +26,21 @@ from skflow.io.data_feeder import setup_train_data_feeder
 # pylint: disable=unused-argument
 # pylint: disable=attribute-defined-outside-init
 
+def default_monitor():
+    return(BaseMonitor())
+
+
 class BaseMonitor(object):
     """ Base class for all learning monitors. Stores and reports training loss throughout learning
 
+        Parameters:
         print_steps: Number of steps in between printing cost.
         early_stopping_rounds:  Activates early stopping if this is not None.
                                 Loss needs to decrease at least every every <early_stopping_rounds>
                                 round(s) to continue training. (default: None)
 
     """
-    def __init__(self, print_steps=100, early_stopping_rounds=500, verbose=1):
+    def __init__(self, print_steps=100, early_stopping_rounds=250, verbose=1):
         self.print_steps = print_steps
         self.early_stopping_rounds = early_stopping_rounds
 
@@ -127,10 +132,15 @@ class ValidationMonitor(BaseMonitor):
         val_X: Validation features
         val_y: Validation labels
         n_classes: Number of labels in output. 0 for regression
-        See BaseMonitor for arguments
+        print_steps: Number of steps in between printing cost.
+        early_stopping_rounds:  Activates early stopping if this is not None.
+                                Loss needs to decrease at least every every <early_stopping_rounds>
+                                round(s) to continue training. (default: None)
+
     """
-    def __init__(self, val_X, val_y, n_classes=0, *args, **kwargs):
-        super(ValidationMonitor, self).__init__()
+    def __init__(self, val_X, val_y, n_classes=0, print_steps=100, early_stopping_rounds=250):
+        super(ValidationMonitor, self).__init__(print_steps=print_steps,
+                                                early_stopping_rounds=early_stopping_rounds)
         self.val_feeder = setup_train_data_feeder(val_X, val_y, n_classes, -1)
         self.print_val_loss_buffer = []
         self.all_val_loss_buffer = []

--- a/skflow/monitors.py
+++ b/skflow/monitors.py
@@ -23,11 +23,11 @@ from skflow.io.data_feeder import setup_train_data_feeder
 # pylint: disable=too-many-instance-attributes
 # pylint: disable=too-few-public-methods
 # pylint: disable=too-many-arguments
-# pylint: disable=unused-argument
 # pylint: disable=attribute-defined-outside-init
 
 def default_monitor():
-    return(BaseMonitor())
+    """returns very simple monitor object to summarize training progress"""
+    return BaseMonitor()
 
 
 class BaseMonitor(object):

--- a/skflow/monitors.py
+++ b/skflow/monitors.py
@@ -35,7 +35,7 @@ class BaseMonitor(object):
                                 round(s) to continue training. (default: None)
 
     """
-    def __init__(self, print_steps=100, early_stopping_rounds=200, verbose=1):
+    def __init__(self, print_steps=100, early_stopping_rounds=500, verbose=1):
         self.print_steps = print_steps
         self.early_stopping_rounds = early_stopping_rounds
 
@@ -80,7 +80,7 @@ class BaseMonitor(object):
 
     def report(self):
         """Checks whether to report, and prints loss information if appropriate"""
-        if self.verbose and self.steps % self.print_steps == 0:
+        if self.verbose and (self.steps % self.print_steps == 0):
             self._set_training_summary()
             print(self._summary_str)
 
@@ -108,7 +108,7 @@ class BaseMonitor(object):
         self.print_train_loss_buffer = []
         if self.epoch:
             self._summary_str = ("Step #{step}, epoch #{epoch}, avg. train loss: {loss:.5f}"
-                                 .format(step=self.global_step, loss=avg_train_loss,
+                                 .format(step=self.steps, loss=avg_train_loss,
                                          epoch=self.epoch))
         else:
             self._summary_str = ("Step #{step}, avg. train loss: {loss:.5f}"

--- a/skflow/monitors.py
+++ b/skflow/monitors.py
@@ -1,0 +1,157 @@
+"""Monitors to track model training, report on progress and request early stopping"""
+#  Copyright 2015-present Scikit Flow Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from __future__ import print_function
+import sys
+import numpy as np
+
+from skflow.io.data_feeder import setup_train_data_feeder
+
+
+# pylint: disable=too-many-instance-attributes
+# pylint: disable=too-few-public-methods
+# pylint: disable=too-many-arguments
+# pylint: disable=unused-argument
+# pylint: disable=attribute-defined-outside-init
+
+class BaseMonitor(object):
+    """ Base class for all learning monitors. Stores and reports training loss throughout learning
+
+        print_steps: Number of steps in between printing cost.
+        early_stopping_rounds:  Activates early stopping if this is not None.
+                                Loss needs to decrease at least every every <early_stopping_rounds>
+                                round(s) to continue training. (default: None)
+
+    """
+    def __init__(self, print_steps=100, early_stopping_rounds=200, verbose=1):
+        self.print_steps = print_steps
+        self.early_stopping_rounds = early_stopping_rounds
+
+        self.converged = False
+        self.min_loss = np.inf
+        self.min_loss_i = 0
+        self.last_loss_seen = np.inf
+        self.steps = 0
+        self.print_train_loss_buffer = []
+        self.all_train_loss_buffer = []
+        self.verbose = verbose
+        self.epoch = None
+
+    def update(self, global_step, step_number, training_loss,
+               sess, feed_params_fn, loss_expression_tensor):
+        """Adds training_loss to monitor. Triggers printed output if appropriate
+
+            global_step:
+            step_number: current step in training
+            training_loss: float value of training loss
+            sess: session for computation (used to calculate validation loss)
+            feed_params_fn: function generating dict with information like epoch. Sometimes None.
+            loss_expression_tensor: Tensor applied to validation data to calculate val loss
+
+        """
+        self.steps = step_number
+        self.global_step = global_step
+        self.print_train_loss_buffer.append(training_loss)
+        self.all_train_loss_buffer.append(training_loss)
+        self.sess = sess
+        self.loss_expression_tensor = loss_expression_tensor
+        self._set_last_loss_seen()
+        if self.last_loss_seen < self.min_loss:
+            self.min_loss = training_loss
+            self.min_loss_i = self.steps
+        self._set_epoch(feed_params_fn)
+        self.report()
+
+    def _set_last_loss_seen(self):
+        """Sets last_loss_seen attribute to most recent training error"""
+        self.last_loss_seen = self.all_train_loss_buffer[-1]
+
+    def report(self):
+        """Checks whether to report, and prints loss information if appropriate"""
+        if self.verbose and self.steps % self.print_steps == 0:
+            self._set_training_summary()
+            print(self._summary_str)
+
+    def monitor_inducing_stop(self):
+        """Returns True if the monitor requests the model stop (e.g. for early stopping)"""
+        stop_now = (self.steps - self.min_loss_i >= self.early_stopping_rounds)
+        if stop_now:
+            sys.stderr.write("Stopping. Best step:\n step {} with loss {}\n"
+                             .format(self.min_loss_i, self.min_loss))
+        return stop_now
+
+    def create_val_feed_dict(self, inp, out):
+        """Validation requires access to TensorFlow placeholders. Not used in this Monitor"""
+        pass
+
+    def _set_epoch(self, feed_params_fn):
+        """Sets self.epoch from a function that generates a dictionary including this info"""
+        if feed_params_fn:
+            feed_params = feed_params_fn()
+            self.epoch = feed_params['epoch'] if 'epoch' in feed_params else None
+
+    def _set_training_summary(self):
+        """Returns the string to be written describing training progress"""
+        avg_train_loss = np.mean(self.print_train_loss_buffer)
+        self.print_train_loss_buffer = []
+        if self.epoch:
+            self._summary_str = ("Step #{step}, epoch #{epoch}, avg. train loss: {loss:.5f}"
+                                 .format(step=self.global_step, loss=avg_train_loss,
+                                         epoch=self.epoch))
+        else:
+            self._summary_str = ("Step #{step}, avg. train loss: {loss:.5f}"
+                                 .format(step=self.global_step,
+                                         loss=avg_train_loss))
+        self._modify_summary_string()
+
+    def _modify_summary_string(self):
+        """Makes monitor specific changes to printed summary. Nothing interesting in BaseMonitor"""
+        pass
+
+
+class ValidationMonitor(BaseMonitor):
+    """Monitor that reports score for validation data and uses validation data for early stopping
+
+        val_X: Validation features
+        val_y: Validation labels
+        n_classes: Number of labels in output. 0 for regression
+        See BaseMonitor for arguments
+    """
+    def __init__(self, val_X, val_y, n_classes=0, *args, **kwargs):
+        super(ValidationMonitor, self).__init__()
+        self.val_feeder = setup_train_data_feeder(val_X, val_y, n_classes, -1)
+        self.print_val_loss_buffer = []
+        self.all_val_loss_buffer = []
+
+    def create_val_feed_dict(self, inp, out):
+        """Set tensorflow placeholders and create validation data feed"""
+        self.val_dict = self.val_feeder.get_feed_dict_fn(inp, out)()
+
+    def _set_last_loss_seen(self):
+        """Sets self.last_loss_seen to most recent validation loss
+
+        Also stores this value to appropriate buffers
+        """
+        [val_loss] = self.sess.run([self.loss_expression_tensor], feed_dict=self.val_dict)
+        self.last_loss_seen = val_loss
+        self.all_val_loss_buffer.append(val_loss)
+        self.print_val_loss_buffer.append(val_loss)
+
+    def _modify_summary_string(self):
+        """Adds validation data to string to print and resets validation printing buffer"""
+        avg_val_loss = np.mean(self.print_val_loss_buffer)
+        self.print_val_loss_buffer = []
+        val_loss_string = "avg. val loss: {val_loss:.5f}".format(val_loss=avg_val_loss)
+        self._summary_str = (", ".join([self._summary_str, val_loss_string]))

--- a/skflow/tests/test_early_stopping.py
+++ b/skflow/tests/test_early_stopping.py
@@ -21,6 +21,7 @@ from sklearn.cross_validation import train_test_split
 
 import skflow
 
+
 class EarlyStoppingTest(tf.test.TestCase):
 
     def testIrisES(self):
@@ -32,17 +33,20 @@ class EarlyStoppingTest(tf.test.TestCase):
                                                             test_size=0.2,
                                                             random_state=42)
 
+        X_train, X_val, y_train, y_val = train_test_split(X_train, y_train, test_size=0.2)
+        val_monitor = skflow.monitors.ValidationMonitor(X_val, y_val, n_classes=3)
+
         # classifier without early stopping - overfitting
         classifier1 = skflow.TensorFlowDNNClassifier(hidden_units=[10, 20, 10],
-                                                    n_classes=3, steps=1000)
+                                                     n_classes=3, steps=1000)
         classifier1.fit(X_train, y_train)
         score1 = metrics.accuracy_score(y_test, classifier1.predict(X_test))
 
         # classifier with early stopping - improved accuracy on testing set
         classifier2 = skflow.TensorFlowDNNClassifier(hidden_units=[10, 20, 10],
-                                                    n_classes=3, steps=1000,
-                                                    early_stopping_rounds=300)
-        classifier2.fit(X_train, y_train)
+                                                     n_classes=3, steps=1000)
+
+        classifier2.fit(X_train, y_train, val_monitor)
         score2 = metrics.accuracy_score(y_test, classifier2.predict(X_test))
 
         # self.assertGreater(score2, score1, "No improvement using early stopping.")


### PR DESCRIPTION
This PR allows a user to specify a validation dataset that are used for early stopping (and reporting). The PR was created to address [issue 85](https://github.com/tensorflow/skflow/issues/85)

I made changes in 3 places. 
1. The trainer now takes a dictionary containing the validation data (in the same format as the output of the data feeder's get_dict_fn). 
2. The fit method now takes arguments for val_X and val_y. It converts these into the correct format for the trainer.
3. The example file digits.py now uses early stopping, by supplying val_X and val_y.

I can add early stopping to other examples if this approach looks good, though their behavior should not otherwise be affected by the current PR.