### PR TITLE
Fix predict data feeder to return non-overlapping batches

### DIFF
--- a/skflow/io/data_feeder.py
+++ b/skflow/io/data_feeder.py
@@ -95,8 +95,9 @@ def _batch_data(X, batch_size):
     chunk = []
     for data in X:
         chunk.append(data)
-        if batch_size > 0 and len(chunk) > batch_size:
+        if batch_size > 0 and len(chunk) >= batch_size:
             yield np.matrix(chunk)
+            chunk = []
     yield np.matrix(chunk)
 
 

--- a/skflow/tests/test_data_feeder.py
+++ b/skflow/tests/test_data_feeder.py
@@ -18,6 +18,7 @@ import numpy as np
 import tensorflow as tf
 
 from skflow import data_feeder
+from skflow.io.data_feeder import setup_predict_data_feeder
 from skflow.io import *
 
 
@@ -103,6 +104,16 @@ class DataFeederTest(tf.test.TestCase):
                                                      [ 0.60000002, 0.2]])
             self.assertAllClose(feed_dict['output'], [[ 0., 0., 1.],
                                                      [ 0., 1., 0.]])
+
+
+class SetupPredictDataFeederTest(tf.test.TestCase):
+
+    def test_iterable_data(self):
+        X = iter([[1, 2], [3, 4], [5, 6]])
+        df = setup_predict_data_feeder(X, batch_size=2)
+        self.assertAllClose(df.next(), [[1, 2], [3, 4]])
+        self.assertAllClose(df.next(), [[5, 6]])
+
 
 if __name__ == '__main__':
     tf.test.main()

--- a/skflow/tests/test_data_feeder.py
+++ b/skflow/tests/test_data_feeder.py
@@ -14,6 +14,7 @@
 
 from struct import Struct
 import numpy as np
+import six
 
 import tensorflow as tf
 
@@ -111,8 +112,8 @@ class SetupPredictDataFeederTest(tf.test.TestCase):
     def test_iterable_data(self):
         X = iter([[1, 2], [3, 4], [5, 6]])
         df = setup_predict_data_feeder(X, batch_size=2)
-        self.assertAllClose(df.next(), [[1, 2], [3, 4]])
-        self.assertAllClose(df.next(), [[5, 6]])
+        self.assertAllClose(six.next(df), [[1, 2], [3, 4]])
+        self.assertAllClose(six.next(df), [[5, 6]])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
setup_predict_data_feeder when given an iterator returns
incorrect batches. The incorrect batches take the following
form.

[0, ..., batch_size]
[0, ..., batch_size, batch_size+1]
...

This commit fixes this to return non-overlapping batches of
sizes equal to batch_size.