### PR TITLE
fix of the rnn_seq2seq in order to be compatible with tensorflow 0.7

### DIFF
--- a/skflow/ops/seq2seq_ops.py
+++ b/skflow/ops/seq2seq_ops.py
@@ -129,6 +129,5 @@ def rnn_seq2seq(encoder_inputs, decoder_inputs, encoder_cell, decoder_cell=None,
         List of tensors for outputs and states for trianing and sampling sub-graphs.
     """
     with tf.variable_scope(scope or "rnn_seq2seq"):
-        _, enc_states = tf.nn.rnn(encoder_cell, encoder_inputs, dtype=dtype)
-        return rnn_decoder(decoder_inputs, enc_states[-1], decoder_cell or encoder_cell)
-
+        _, last_enc_state = tf.nn.rnn(encoder_cell, encoder_inputs, dtype=dtype)
+        return rnn_decoder(decoder_inputs, last_enc_state, decoder_cell or encoder_cell)


### PR DESCRIPTION
This PR is addition to #119 and fixes issue #121

Since tensorflow 0.7. `tf.nn.rnn()` does return only the last state, so `seq2seq_ops.py` file needs this update where returned element is treated as tensor, not list of tensors. 