### PR TITLE
move monitor and logdir arguments to init

### DIFF
--- a/skflow/estimators/dnn.py
+++ b/skflow/estimators/dnn.py
@@ -55,13 +55,17 @@ class TensorFlowDNNClassifier(TensorFlowEstimator, ClassifierMixin):
             Defaults to 5 (that is, the 5 most recent checkpoint files are kept.)
         keep_checkpoint_every_n_hours: Number of hours between each checkpoint
             to be saved. The default value of 10,000 hours effectively disables the feature.
+        logdir: the directory to save the log file that can be used for
+            optional visualization.
+        monitor: Monitor object to print training progress and invoke early stopping
      """
 
     def __init__(self, hidden_units, n_classes, tf_master="", batch_size=32,
                  steps=200, optimizer="SGD", learning_rate=0.1,
                  class_weight=None,
                  tf_random_seed=42, continue_training=False, config_addon=None,
-                 verbose=1, max_to_keep=5, keep_checkpoint_every_n_hours=10000):
+                 verbose=1, max_to_keep=5, keep_checkpoint_every_n_hours=10000,
+                 logdir=None, monitor=None):
 
         self.hidden_units = hidden_units
         super(TensorFlowDNNClassifier, self).__init__(
@@ -73,7 +77,8 @@ class TensorFlowDNNClassifier(TensorFlowEstimator, ClassifierMixin):
             continue_training=continue_training,
             config_addon=config_addon, verbose=verbose,
             max_to_keep=max_to_keep,
-            keep_checkpoint_every_n_hours=keep_checkpoint_every_n_hours)
+            keep_checkpoint_every_n_hours=keep_checkpoint_every_n_hours,
+            logdir=logdir, monitor=monitor)
 
     def _model_fn(self, X, y):
         return models.get_dnn_model(self.hidden_units,
@@ -132,12 +137,16 @@ class TensorFlowDNNRegressor(TensorFlowEstimator, RegressorMixin):
             Defaults to 5 (that is, the 5 most recent checkpoint files are kept.)
         keep_checkpoint_every_n_hours: Number of hours between each checkpoint
             to be saved. The default value of 10,000 hours effectively disables the feature.
+        logdir: the directory to save the log file that can be used for
+            optional visualization.
+        monitor: Monitor object to print training progress and invoke early stopping
    """
 
     def __init__(self, hidden_units, n_classes=0, tf_master="", batch_size=32,
                  steps=200, optimizer="SGD", learning_rate=0.1,
                  tf_random_seed=42, continue_training=False, config_addon=None,
-                 verbose=1, max_to_keep=5, keep_checkpoint_every_n_hours=10000):
+                 verbose=1, max_to_keep=5, keep_checkpoint_every_n_hours=10000,
+                 logdir=None, monitor=None):
 
         self.hidden_units = hidden_units
         super(TensorFlowDNNRegressor, self).__init__(
@@ -148,7 +157,8 @@ class TensorFlowDNNRegressor(TensorFlowEstimator, RegressorMixin):
             continue_training=continue_training,
             config_addon=config_addon, verbose=verbose,
             max_to_keep=max_to_keep,
-            keep_checkpoint_every_n_hours=keep_checkpoint_every_n_hours)
+            keep_checkpoint_every_n_hours=keep_checkpoint_every_n_hours,
+            logdir=logdir, monitor=monitor)
 
     def _model_fn(self, X, y):
         return models.get_dnn_model(self.hidden_units,

--- a/skflow/estimators/linear.py
+++ b/skflow/estimators/linear.py
@@ -27,7 +27,8 @@ class TensorFlowLinearRegressor(TensorFlowEstimator, RegressorMixin):
     def __init__(self, n_classes=0, tf_master="", batch_size=32, steps=200, optimizer="SGD",
                  learning_rate=0.1, tf_random_seed=42, continue_training=False,
                  config_addon=None, verbose=1,
-                 max_to_keep=5, keep_checkpoint_every_n_hours=10000):
+                 max_to_keep=5, keep_checkpoint_every_n_hours=10000,
+                 logdir=None, monitor=None):
 
         super(TensorFlowLinearRegressor, self).__init__(
             model_fn=models.linear_regression, n_classes=n_classes,
@@ -36,7 +37,8 @@ class TensorFlowLinearRegressor(TensorFlowEstimator, RegressorMixin):
             learning_rate=learning_rate, tf_random_seed=tf_random_seed,
             continue_training=continue_training, config_addon=config_addon,
             verbose=verbose, max_to_keep=max_to_keep,
-            keep_checkpoint_every_n_hours=keep_checkpoint_every_n_hours)
+            keep_checkpoint_every_n_hours=keep_checkpoint_every_n_hours,
+            logdir=logdir, monitor=monitor)
 
     @property
     def weights_(self):
@@ -55,7 +57,8 @@ class TensorFlowLinearClassifier(TensorFlowEstimator, ClassifierMixin):
     def __init__(self, n_classes, tf_master="", batch_size=32, steps=200, optimizer="SGD",
                  learning_rate=0.1, class_weight=None,
                  tf_random_seed=42, continue_training=False, config_addon=None,
-                 verbose=1, max_to_keep=5, keep_checkpoint_every_n_hours=10000):
+                 verbose=1, max_to_keep=5, keep_checkpoint_every_n_hours=10000,
+                 logdir=None, monitor=None):
 
         super(TensorFlowLinearClassifier, self).__init__(
             model_fn=models.logistic_regression, n_classes=n_classes,
@@ -65,7 +68,8 @@ class TensorFlowLinearClassifier(TensorFlowEstimator, ClassifierMixin):
             tf_random_seed=tf_random_seed,
             continue_training=continue_training, config_addon=config_addon,
             verbose=verbose, max_to_keep=max_to_keep,
-            keep_checkpoint_every_n_hours=keep_checkpoint_every_n_hours)
+            keep_checkpoint_every_n_hours=keep_checkpoint_every_n_hours,
+            logdir=logdir, monitor=monitor)
 
     @property
     def weights_(self):

--- a/skflow/estimators/rnn.py
+++ b/skflow/estimators/rnn.py
@@ -69,6 +69,9 @@ class TensorFlowRNNClassifier(TensorFlowEstimator, ClassifierMixin):
             Defaults to 5 (that is, the 5 most recent checkpoint files are kept.)
         keep_checkpoint_every_n_hours: Number of hours between each checkpoint
             to be saved. The default value of 10,000 hours effectively disables the feature.
+        logdir: the directory to save the log file that can be used for
+            optional visualization.
+        monitor: Monitor object to print training progress and invoke early stopping
      """
 
     def __init__(self, rnn_size, n_classes, cell_type='gru', num_layers=1,
@@ -79,7 +82,8 @@ class TensorFlowRNNClassifier(TensorFlowEstimator, ClassifierMixin):
                  class_weight=None,
                  tf_random_seed=42, continue_training=False,
                  config_addon=None, verbose=1,
-                 max_to_keep=5, keep_checkpoint_every_n_hours=10000):
+                 max_to_keep=5, keep_checkpoint_every_n_hours=10000,
+                 logdir=None, monitor=None):
 
         self.rnn_size = rnn_size
         self.cell_type = cell_type
@@ -97,7 +101,8 @@ class TensorFlowRNNClassifier(TensorFlowEstimator, ClassifierMixin):
             continue_training=continue_training, config_addon=config_addon,
             verbose=verbose,
             max_to_keep=max_to_keep,
-            keep_checkpoint_every_n_hours=keep_checkpoint_every_n_hours)
+            keep_checkpoint_every_n_hours=keep_checkpoint_every_n_hours,
+            logdir=logdir, monitor=monitor)
 
     def _model_fn(self, X, y):
         return models.get_rnn_model(self.rnn_size, self.cell_type,
@@ -161,6 +166,9 @@ class TensorFlowRNNRegressor(TensorFlowEstimator, RegressorMixin):
             Defaults to 5 (that is, the 5 most recent checkpoint files are kept.)
         keep_checkpoint_every_n_hours: Number of hours between each checkpoint
             to be saved. The default value of 10,000 hours effectively disables the feature.
+        logdir: the directory to save the log file that can be used for
+            optional visualization.
+        monitor: Monitor object to print training progress and invoke early stopping
    """
 
     def __init__(self, rnn_size, cell_type='gru', num_layers=1,
@@ -170,7 +178,8 @@ class TensorFlowRNNRegressor(TensorFlowEstimator, RegressorMixin):
                  steps=50, optimizer="SGD", learning_rate=0.1,
                  tf_random_seed=42, continue_training=False,
                  config_addon=None, verbose=1,
-                 max_to_keep=5, keep_checkpoint_every_n_hours=10000):
+                 max_to_keep=5, keep_checkpoint_every_n_hours=10000,
+                 logdir=None, monitor=None):
 
         self.rnn_size = rnn_size
         self.cell_type = cell_type
@@ -186,7 +195,8 @@ class TensorFlowRNNRegressor(TensorFlowEstimator, RegressorMixin):
             learning_rate=learning_rate, tf_random_seed=tf_random_seed,
             continue_training=continue_training, config_addon=config_addon,
             verbose=verbose, max_to_keep=max_to_keep,
-            keep_checkpoint_every_n_hours=keep_checkpoint_every_n_hours)
+            keep_checkpoint_every_n_hours=keep_checkpoint_every_n_hours,
+            logdir=logdir, monitor=monitor)
 
     def _model_fn(self, X, y):
         return models.get_rnn_model(self.rnn_size, self.cell_type,

--- a/skflow/tests/test_base.py
+++ b/skflow/tests/test_base.py
@@ -52,11 +52,11 @@ class BaseTest(tf.test.TestCase):
 
     def testIrisSummaries(self):
         iris = datasets.load_iris()
-        classifier = skflow.TensorFlowLinearClassifier(n_classes=3)
-        classifier.fit(iris.data, iris.target, logdir='/tmp/skflow_tests/')
+        classifier = skflow.TensorFlowLinearClassifier(
+            n_classes=3, logdir='/tmp/skflow_tests/')
+        classifier.fit(iris.data, iris.target)
         score = accuracy_score(iris.target, classifier.predict(iris.data))
         self.assertGreater(score, 0.5, "Failed with score = {0}".format(score))
-
 
     def testIrisContinueTraining(self):
         iris = datasets.load_iris()

--- a/skflow/tests/test_early_stopping.py
+++ b/skflow/tests/test_early_stopping.py
@@ -44,9 +44,10 @@ class EarlyStoppingTest(tf.test.TestCase):
 
         # classifier with early stopping - improved accuracy on testing set
         classifier2 = skflow.TensorFlowDNNClassifier(hidden_units=[10, 20, 10],
-                                                     n_classes=3, steps=1000)
+                                                     n_classes=3, steps=1000,
+                                                     monitor=val_monitor)
 
-        classifier2.fit(X_train, y_train, val_monitor)
+        classifier2.fit(X_train, y_train)
         score2 = metrics.accuracy_score(y_test, classifier2.predict(X_test))
 
         # self.assertGreater(score2, score1, "No improvement using early stopping.")


### PR DESCRIPTION
This moves the `monitor` and `logdir` arguments for the `fit` method to the base estimator `__init__` method so that `fit` better follows the sklearn API guidelines: ["fit parameters should be restricted to directly data dependent variables"](http://scikit-learn.org/stable/developers/contributing.html#fitting).  This should make it easier to use, e.g., `GridSearchCV` with skflow models.