### PR TITLE
Predict batch size default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# example log output
+examples/example_logs/

--- a/examples/README.md
+++ b/examples/README.md
@@ -3,6 +3,7 @@
 * [Deep Neural Network Regression with Boston Data](boston.py)
 * [Convolutional Neural Networks with Digits Data](digits.py)
 * [Deep Neural Network Classification with Iris Data](iris.py)
+* [Grid search and Deep Neural Network Classification](iris_gridsearch_cv.py)
 * [Deep Neural Network with Customized Decay Function](iris_custom_decay_dnn.py)
 * [Building A Custom Model](iris_custom_model.py)
 * [Accessing Weights and Biases in A Custom Model](mnist_weights.py)
@@ -23,7 +24,7 @@
 
 ## Text classification
 
-* [Text Classification Using Recurrent Neural Networks on Words](text_classification.py) 
+* [Text Classification Using Recurrent Neural Networks on Words](text_classification.py)
 (See also [Simplified Version Using Built-in RNN Model](text_classification_builtin_rnn_model.py) using built-in parameters)
 * [Text Classification Using Convolutional Neural Networks on Words](text_classification_cnn.py)
 * [Text Classification Using Recurrent Neural Networks on Characters](text_classification_character_rnn.py)
@@ -39,4 +40,3 @@
 
 * [Character level neural language translation](neural_translation.py)
 * [Word level neural language translation](neural_translation_word.py)
-

--- a/examples/iris_gridsearch_cv.py
+++ b/examples/iris_gridsearch_cv.py
@@ -1,0 +1,43 @@
+#  Copyright 2015-present Scikit Flow Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from sklearn import datasets, metrics, grid_search, cross_validation
+
+import skflow
+
+# Load dataset.
+iris = datasets.load_iris()
+X_train, X_test, y_train, y_test = \
+    cross_validation.train_test_split(
+        iris.data, iris.target, test_size=0.2, random_state=42)
+
+# Fit and cross-validate DNN classifiers with 1-4 layers.
+# Use fit_params to specify a directory for logging output (fit_params could
+# also be used to specify a training monitor).
+param_grid = [{'hidden_units':
+               [[10], [10, 10], [10, 10, 10], [10, 10, 10, 10]]}]
+classifier = skflow.TensorFlowDNNClassifier(hidden_units=[10],
+    n_classes=3, steps=200)
+fit_params = {"logdir": "example_logs"}
+gs = grid_search.GridSearchCV(classifier, param_grid,
+                              fit_params=fit_params,
+                              scoring='accuracy')
+gs.fit(X_train, y_train)
+
+# Fit and print the best score and corresponding parameters.
+print('best CV accuracy from grid search: {0:f}'.format(gs.best_score_))
+print('corresponding parameters: {}'.format(gs.best_params_))
+
+score_test = metrics.accuracy_score(y_test, gs.predict(X_test))
+print('accuracy on held-out data: {0:f}'.format(score_test))

--- a/skflow/estimators/base.py
+++ b/skflow/estimators/base.py
@@ -267,9 +267,14 @@ class TensorFlowEstimator(BaseEstimator):
         """
         return self.fit(X, y)
 
-    def _predict(self, X, axis=-1, batch_size=-1):
+    def _predict(self, X, axis=-1, batch_size=None):
         if not self._initialized:
             raise NotFittedError()
+
+        # Use the batch size for fitting if the user did not specify one.
+        if batch_size is None:
+            batch_size = self.batch_size
+
         self._graph.add_to_collection("IS_TRAINING", False)
         predict_data_feeder = setup_predict_data_feeder(
             X, batch_size=batch_size)
@@ -288,7 +293,7 @@ class TensorFlowEstimator(BaseEstimator):
 
         return np.concatenate(preds, axis=0)
 
-    def predict(self, X, axis=1, batch_size=-1):
+    def predict(self, X, axis=1, batch_size=None):
         """Predict class or regression for X.
 
         For a classification model, the predicted class for each sample in X is
@@ -301,7 +306,8 @@ class TensorFlowEstimator(BaseEstimator):
                   By default axis 1 (next after batch) is used.
                   Use 2 for sequence predictions.
             batch_size: If test set is too big, use batch size to split
-                        it into mini batches. By default full dataset is used.
+                        it into mini batches. By default the batch_size member
+                        variable is used.
 
         Returns:
             y: array of shape [n_samples]. The predicted classes or predicted
@@ -309,13 +315,14 @@ class TensorFlowEstimator(BaseEstimator):
         """
         return self._predict(X, axis=axis, batch_size=batch_size)
 
-    def predict_proba(self, X, batch_size=-1):
+    def predict_proba(self, X, batch_size=None):
         """Predict class probability of the input samples X.
 
         Args:
             X: array-like matrix, [n_samples, n_features...] or iterator.
             batch_size: If test set is too big, use batch size to split
-                        it into mini batches. By default full dataset is used.
+                        it into mini batches. By default the batch_size
+                        member variable is used.
 
         Returns:
             y: array of shape [n_samples, n_classes]. The predicted


### PR DESCRIPTION
This changes the default batch size for prediction to be the same as for training, enabling efficient grid search.  Previously `GridSearchCV` would try to make predictions in a single batch, which could take a lot of memory.

This also adds a simple example of using skflow with `GridSearchCV`.