### PR TITLE
Use the public TensorFlow API to access SaverDef

### DIFF
--- a/skflow/estimators/base.py
+++ b/skflow/estimators/base.py
@@ -425,7 +425,7 @@ class TensorFlowEstimator(BaseEstimator):
             if not os.path.exists(saver_filename):
                 raise ValueError("Restore folder doesn't contain saver defintion.")
             with open(saver_filename) as fsaver:
-                saver_def = tf.python.training.saver.saver_pb2.SaverDef()
+                saver_def = tf.train.SaverDef()
                 text_format.Merge(fsaver.read(), saver_def)
                 self._saver = tf.train.Saver(saver_def=saver_def)
 


### PR DESCRIPTION
The current code accesses SaverDef using an obsolete private API. This change makes skflow compatible with TensorFlow 0.7.0 and up.