### PR TITLE
Removed redundant instance of StandardScaler

### DIFF
--- a/examples/iris_with_pipeline.py
+++ b/examples/iris_with_pipeline.py
@@ -29,7 +29,7 @@ scaler = StandardScaler()
 # DNN classifier
 DNNclassifier = skflow.TensorFlowDNNClassifier(hidden_units=[10, 20, 10], n_classes=3, steps=200)
 
-pipeline = Pipeline([('scaler', StandardScaler()), ('DNNclassifier', DNNclassifier)])
+pipeline = Pipeline([('scaler', scaler, ('DNNclassifier', DNNclassifier)])
 
 pipeline.fit(X_train, y_train)
 


### PR DESCRIPTION
Changed Pipeline to use the existing instance of StandardScaler instead of creating a new instance when Pipeline is created.