### PR TITLE
Fix Python3 errors for cPickle

### DIFF
--- a/examples/neural_translation_word.py
+++ b/examples/neural_translation_word.py
@@ -16,7 +16,7 @@
 
 from __future__ import division, print_function, absolute_import
 
-import cPickle
+from six.moves import cPickle
 import itertools
 import os
 import random
@@ -101,11 +101,11 @@ if not (os.path.exists('en.vocab') and os.path.exists('fr.vocab')):
     X_vocab_processor.fit(Xtrainff)
     print('Fitting dictionary for French...')
     y_vocab_processor.fit(ytrainff)
-    open('en.vocab', 'w').write(cPickle.dumps(X_vocab_processor))
-    open('fr.vocab', 'w').write(cPickle.dumps(y_vocab_processor))
+    open('en.vocab', 'wb').write(cPickle.dumps(X_vocab_processor))
+    open('fr.vocab', 'wb').write(cPickle.dumps(y_vocab_processor))
 else:
-    X_vocab_processor = cPickle.loads(open('en.vocab').read())
-    y_vocab_processor = cPickle.loads(open('fr.vocab').read())
+    X_vocab_processor = cPickle.loads(open('en.vocab', 'rb').read())
+    y_vocab_processor = cPickle.loads(open('fr.vocab', 'rb').read())
 print('Transforming...')
 X_train = X_vocab_processor.transform(X_train)
 y_train = y_vocab_processor.transform(y_train)

--- a/skflow/preprocessing/text.py
+++ b/skflow/preprocessing/text.py
@@ -16,7 +16,7 @@
 from __future__ import division, print_function, absolute_import
 
 import re
-import cPickle
+from six.moves import cPickle
 import six
 
 import numpy as np
@@ -202,7 +202,7 @@ class VocabularyProcessor(object):
         Args:
             filename: Path to output file.
         """
-        open(filename, 'w').write(cPickle.dumps(self))
+        open(filename, 'wb').write(cPickle.dumps(self))
 
     @classmethod
     def restore(cls, filename):
@@ -214,5 +214,5 @@ class VocabularyProcessor(object):
         Returns:
             VocabularyProcessor object.
         """
-        return cPickle.loads(open(filename).read())
+        return cPickle.loads(open(filename, 'rb').read())
 


### PR DESCRIPTION
Build for Python3 was broken in a9a488d; apparently that was just yesterday but I didn't want to wait :rocket:.