### PR TITLE
Update TensorFlow repo skflow URL in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,10 +1,10 @@
 SkFlow has been moved to Tensorflow.
 ====================================
 
-SkFlow has been moved to http://github.com/tensorflow/tensorflow into contrib folder specifically located `here <https://github.com/tensorflow/tensorflow/tree/master/tensorflow/contrib/skflow/python/skflow>`__.
+SkFlow has been moved to http://github.com/tensorflow/tensorflow into contrib folder specifically located `here <https://github.com/tensorflow/tensorflow/tree/master/tensorflow/contrib/learn/python/learn>`__.
 The development will continue there. Please submit any issues and pull requests to Tensorflow repository instead. 
 
-This repository will ramp down, including after next Tensorflow release we will wind down code here. Please see instructions on most recent installation `here <https://github.com/tensorflow/tensorflow/tree/master/tensorflow/contrib/skflow/python/skflow>`__.
+This repository will ramp down, including after next Tensorflow release we will wind down code here. Please see instructions on most recent installation `here <https://github.com/tensorflow/tensorflow/tree/master/tensorflow/contrib/learn/python/learn>`__.
 
 Previously:
 


### PR DESCRIPTION
This replaces a URL that was 404ing with a path in the TensorFlow repo that contains the README for TF Learn (aka Scikit Flow)