### PR TITLE
sudo keyword deprecated #188

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: true
 dist: trusty
 
 language: python


### PR DESCRIPTION
[Based on this blog from Travis CI team](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration)